### PR TITLE
[fix]webの場合はtokenをcookieにセット

### DIFF
--- a/app/interfaces/server.go
+++ b/app/interfaces/server.go
@@ -61,6 +61,8 @@ func (s *Server) Route() {
 	})
 	s.Router.Post("/sign/up", authHandler.SignUp)
 	s.Router.Post("/login", authHandler.SignIn)
+	//応急処置
+	s.Router.Post("/mlogin", authHandler.SignInMobile)
 
 	// auth
 	s.Router.Group(func(mux chi.Router) {


### PR DESCRIPTION
[issue](https://github.com/Funcy-ICT/Funcy_Portfolio_Backend/issues/35)
## 概要
webの場合はtokenをcookieにセットするようにしました。
mobileと処理を分ける都合上エンドポイントを分けました。

## 確認したこと
cookieがsetされている
<img width="990" alt="スクリーンショット 2022-12-04 18 02 04" src="https://user-images.githubusercontent.com/49856793/205482461-6c104c8a-d311-4cc2-9628-e4dd57f6d0fc.png">


## 検討事項
user-agentによる判別は問題が多いので修正する必要あり
HttpOnlyとSecureについてはフロントチームと要相談