### PR TITLE
ワンタイムパスワード認証時にtokenを返却

### DIFF
--- a/app/domain/repository/auth_repository.go
+++ b/app/domain/repository/auth_repository.go
@@ -7,4 +7,5 @@ type AuthRepository interface {
 	GetPassword(mail string) (entity.User, error)
 	CheckMailAddr(userID string) (string, error)
 	UpdateStatus(userID string) error
+	GetToken(userID string) (string, error)
 }

--- a/app/infrastructure/auth.go
+++ b/app/infrastructure/auth.go
@@ -61,3 +61,12 @@ func (ur *userRepositoryImpl) GetPassword(mail string) (entity.User, error) {
 	}
 	return user, nil
 }
+
+func (ur *userRepositoryImpl) GetToken(userID string) (string, error) {
+	var user entity.User
+	err := ur.db.Get(&user, `SELECT token FROM users WHERE id=?`, userID)
+	if err != nil {
+		return "", errors.New("Not a valid code")
+	}
+	return user.Token, nil
+}

--- a/app/interfaces/handler/auth.go
+++ b/app/interfaces/handler/auth.go
@@ -133,13 +133,15 @@ func (h *AuthHandler) AuthCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = h.authUseCase.CheckMail(req)
+	token, err := h.authUseCase.CheckMail(req)
 	if err != nil {
 		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	res := "ok"
+	res := response.Token{
+		Token: token,
+	}
 	resBody, err := json.Marshal(res)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/app/usecase/auth.go
+++ b/app/usecase/auth.go
@@ -102,18 +102,21 @@ func (a *AuthUseCase) LoginMobile(r request.SignInRequest) (string, error) {
 	return jwt, nil
 }
 
-func (a *AuthUseCase) CheckMail(r request.AuthCodeRequest) error {
+func (a *AuthUseCase) CheckMail(r request.AuthCodeRequest) (string, error) {
 
 	code, err := a.authRepository.CheckMailAddr(r.UserID)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if code != r.Code {
-		return errors.New("not match code")
+		return "", errors.New("not match code")
 	}
 	err = a.authRepository.UpdateStatus(r.UserID)
 	if code != r.Code {
-		return err
+		return "", err
 	}
-	return nil
+
+	token, err := a.authRepository.GetToken(r.UserID)
+
+	return token, nil
 }

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -684,6 +684,10 @@ components:
           type: string
           description:  ユーザID
           example: kajsdfiow
+        code:
+          type: string
+          description: ワンタイムパスワード
+          example: 123456
     AuthCodeResponse:
       type: object
       properties:

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -34,6 +34,10 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SignUpResponse'
         '400':
           description: Bad Request
           content:
@@ -483,6 +487,11 @@ components:
       required:
         - userID
         - password
+    SignUpResponse:
+      type: object
+      properties:
+        userID:
+          type: string
     SignInRequest:
       type: object
       properties:
@@ -678,10 +687,11 @@ components:
     AuthCodeResponse:
       type: object
       properties:
-        code:
-          type: integer
-          description: ステータスコード
-          example: 123456
+        token:
+          type: string
+          description: jwts
+      required:
+        - token
     ErrorResponse:
       type: object
       properties:


### PR DESCRIPTION
### 概要
ワンタイムパスワード認証時にtokenを返却するように処理を修正しました。
あわせて修正内容に合わせてswaggerの修正も行いました。

### 確認したこと
- レスポンスが想定通りか
- 想定したデータが格納されているか

### 確認してほしいこと
- 記法
- API のresponse bodyに齟齬がないか