### PR TITLE
[fix] #56 go1.20.4へのアップグレード

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as dev
+FROM golang:1.20-alpine as dev
 RUN apk update && \
     apk upgrade && \
     apk add bash git && \
@@ -7,7 +7,7 @@ RUN apk update && \
 
 RUN go install github.com/cespare/reflex@latest
 
-FROM golang:1.19-alpine
+FROM golang:1.20-alpine
 COPY --from=dev /go/bin/reflex /go/bin/reflex
 
 RUN apk update && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module backend
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
@@ -15,7 +15,6 @@ require (
 	github.com/mileusna/useragent v1.2.1
 	github.com/pkg/errors v0.9.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 )
 
 require (
@@ -24,5 +23,4 @@ require (
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/stretchr/testify v1.8.0 // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
-	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -54,11 +54,7 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gGKlE2+asNV9m7xrywl36YYNnBG5ZQ0r/BOOxqPpmk=
-gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc/go.mod h1:m7x9LTH6d71AHyAX77c9yqWCCa3UKHcVEj9y7hAtKDk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df h1:n7WqCuqOuCbNr617RXOY0AWRXxgwEyPp2z+p0+hgMuE=
-gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df/go.mod h1:LRQQ+SO6ZHR7tOkpBDuZnXENFzX8qRjMDMyPD6BRkCw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
### 対応issue

https://github.com/Funcy-ICT/Funcy_Portfolio_Backend/issues/56

### 概要
Go 1.20.4

### 確認したこと
エラーなくビルドできる
docker上で動いているgoが現時点での最新ver (1.20.4)にアップグレードされている

### 留意事項
delevopブランチに更新して問題ないか
go.modの更新の際、gomail等の一部の依存関係が消えているが、これは戻しておくべきか