### PR TITLE
[fix]作品取得APIのレスポンスにユーザのアイコンと表示名を返す

### DIFF
--- a/app/domain/entity/work.go
+++ b/app/domain/entity/work.go
@@ -28,6 +28,7 @@ type (
 	ReadWork struct {
 		Title       string   `db:"title"`
 		Description string   `db:"description"`
+		UserId      string   `db:"user_id"`
 		ImageURLs   []string `db:"image_url"`
 		Tags        []string `db:"tag"`
 		WorkURL     string   `db:"url"`

--- a/app/domain/repository/work_repository.go
+++ b/app/domain/repository/work_repository.go
@@ -5,6 +5,7 @@ import "backend/app/domain/entity"
 type WorkRepository interface {
 	InsertWork(userID string, work *entity.WorkTable, images *[]entity.Image, tags *[]entity.Tag) error
 	SelectWork(workID string) (*entity.ReadWork, error)
+	SelectWorkUser(userID string) (*entity.User, error)
 	SelectWorks(numberOfWorks uint) (*[]*entity.ReadWorksList, error)
 	DeleteWork(workID string) error
 }

--- a/app/infrastructure/work.go
+++ b/app/infrastructure/work.go
@@ -57,21 +57,35 @@ func (ur *workRepositoryImpl) SelectWorks(numberOfWorks uint) (*[]*entity.ReadWo
 	return works, nil
 }
 
+func (ur *workRepositoryImpl) SelectWorkUser(userID string) (*entity.User, error) {
+	var user entity.User
+	err := ur.db.Get(
+		&user,
+		"select users.icon, users.display_name from users where users.id = ?",
+		userID)
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
 func (ur *workRepositoryImpl) SelectWork(workID string) (*entity.ReadWork, error) {
 	work := new(entity.ReadWork)
 
 	if err := ur.db.Get(work,
-		"SELECT works.title, works.description, works.url, works.movie_url, works.security from works where works.id = ?", workID); err != nil {
+		"SELECT works.title, works.description, works.user_id, works.url, works.movie_url, works.security from works where works.id = ?", workID); err != nil {
+		log.Println("work", err)
 		return nil, err
 	}
-
 	if err := ur.db.Select(&work.ImageURLs,
 		"SELECT work_images.image_url from work_images where work_images.work_id = ?", workID); err != nil {
+		log.Println("urls", err)
 		return nil, err
 	}
 
 	if err := ur.db.Select(&work.Tags,
 		"SELECT work_tags.tag from work_tags where work_tags.work_id = ?", workID); err != nil {
+		log.Println("tags", err)
 		return nil, err
 	}
 

--- a/app/interfaces/handler/work.go
+++ b/app/interfaces/handler/work.go
@@ -69,7 +69,7 @@ func (h *WorkHandler) ReadWork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	raw, err := h.workUseCase.ReadWork(workID)
+	raw, user, err := h.workUseCase.ReadWork(workID)
 	if err != nil {
 		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
 		return
@@ -92,6 +92,8 @@ func (h *WorkHandler) ReadWork(w http.ResponseWriter, r *http.Request) {
 	res := &response.ReadWork{
 		Title:       raw.Title,
 		Description: raw.Description,
+		UserIcon:    user.Icon,
+		UserName:    user.DisplayName,
 		Images:      images,
 		WorkURL:     raw.WorkURL,
 		MovieUrl:    raw.MovieUrl,

--- a/app/interfaces/response/work.go
+++ b/app/interfaces/response/work.go
@@ -13,6 +13,8 @@ type (
 	ReadWork struct {
 		Title       string  `json:"title"`
 		Description string  `json:"description"`
+		UserIcon    string  `json:"user_icon"`
+		UserName    string  `json:"user_name"`
 		Images      []Image `json:"images"`
 		WorkURL     string  `json:"work_url"`
 		MovieUrl    string  `json:"movie_url"`

--- a/app/usecase/work.go
+++ b/app/usecase/work.go
@@ -47,12 +47,16 @@ func (w *WorkUseCase) ReadWorks(numberOfWorks uint) (*[]*entity.ReadWorksList, e
 	return works, nil
 }
 
-func (w *WorkUseCase) ReadWork(workID string) (*entity.ReadWork, error) {
+func (w *WorkUseCase) ReadWork(workID string) (*entity.ReadWork, *entity.User, error) {
 	work, err := w.workRepository.SelectWork(workID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return work, nil
+	user, err := w.workRepository.SelectWorkUser(work.UserId)
+	if err != nil {
+		return nil, nil, err
+	}
+	return work, user, nil
 }
 
 func (w *WorkUseCase) DeleteWork(workID string) error {

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -630,6 +630,14 @@ components:
           type: string
           description: 説明文
           example: 我々取材班はFUNcyチームのメンバーがタイムカードを切って残業している姿を激写してしまった．
+        user_icon:
+          type: string
+          description: ユーザアイコン
+          example: https://
+        user_name:
+          type: string
+          description: ユーザ名
+          example: FUN太郎
         images:
           type: array
           items:


### PR DESCRIPTION
### 概要
作品詳細にユーザのアイコンと表示名を表示する必要があるためそれらの情報を作品詳細取得時に返すように修正

### issue
https://github.com/Funcy-ICT/Funcy_Portfolio_Backend/issues/74

### 検証
<img width="835" alt="スクリーンショット 2023-06-01 13 22 59" src="https://github.com/Funcy-ICT/Funcy_Portfolio_Backend/assets/49856793/0778931e-acd7-4eed-81e3-56d090c8e984">
