### PR TITLE
[fix] ReadWorksの内容をworkIDごとに 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as dev
+FROM golang:1.20-alpine as dev
 RUN apk update && \
     apk upgrade && \
     apk add bash git && \
@@ -7,7 +7,7 @@ RUN apk update && \
 
 RUN go install github.com/cespare/reflex@latest
 
-FROM golang:1.19-alpine
+FROM golang:1.20-alpine
 COPY --from=dev /go/bin/reflex /go/bin/reflex
 
 RUN apk update && \

--- a/app/domain/entity/work.go
+++ b/app/domain/entity/work.go
@@ -35,7 +35,6 @@ type (
 		WorkID      string `db:"id"`
 		Title       string `db:"title"`
 		Thumbnail   string `db:"thumbnail"`
-		Images      string `db:"image_url"`
 		Description string `db:"description"`
 		Icon        string `db:"icon"`
 	}

--- a/app/infrastructure/work.go
+++ b/app/infrastructure/work.go
@@ -26,6 +26,7 @@ VALUES (?,?,?,?,?,?,?,?)`,
 	if err != nil {
 		return err
 	}
+
 	_, err = tx.NamedExec(`INSERT INTO work_images (id,work_id,image_url) VALUES (:id,:work_id,:image_url)`,
 		*images)
 	if err != nil {
@@ -48,7 +49,7 @@ func (ur *workRepositoryImpl) SelectWorks(numberOfWorks uint) (*[]*entity.ReadWo
 	works := new([]*entity.ReadWorksList)
 	err := ur.db.Select(
 		works,
-		"SELECT works.id, works.title, work_images.image_url, works.description, thumbnail, users.icon FROM works INNER JOIN work_images ON works.id = work_images.work_id INNER JOIN users ON works.user_id = users.id ORDER BY works.created_at DESC LIMIT ?",
+		"SELECT works.id, works.title, works.description, works.thumbnail, users.icon FROM works INNER JOIN work_images ON works.id = work_images.work_id INNER JOIN users ON works.user_id = users.id ORDER BY works.created_at DESC LIMIT ?",
 		numberOfWorks)
 	if err != nil {
 		return nil, err
@@ -73,9 +74,10 @@ func (ur *workRepositoryImpl) SelectWork(workID string) (*entity.ReadWork, error
 	work := new(entity.ReadWork)
 
 	if err := ur.db.Get(work,
-		"SELECT works.title, works.description, thumbnail, works.url, works.movie_url, works.security from works where works.id = ?", workID); err != nil {
+		"SELECT works.title, works.description, works.user_id, works.thumbnail, works.url, works.movie_url, works.security from works where works.id = ?", workID); err != nil {
 		return nil, err
 	}
+
 	if err := ur.db.Select(&work.ImageURLs,
 		"SELECT work_images.image_url from work_images where work_images.work_id = ?", workID); err != nil {
 		log.Println("urls", err)

--- a/app/interfaces/handler/work.go
+++ b/app/interfaces/handler/work.go
@@ -135,7 +135,7 @@ func (h *WorkHandler) ReadWorks(w http.ResponseWriter, r *http.Request) {
 
 	worksRes := []response.ReadWorks{}
 	for _, work := range *works {
-		newWorkRes := response.ReadWorks{WorkID: work.WorkID, Title: work.Title, Thumbnail: work.Thumbnail, Image: work.Images, Description: work.Description, Icon: work.Icon}
+		newWorkRes := response.ReadWorks{WorkID: work.WorkID, Title: work.Title, Thumbnail: work.Thumbnail, Description: work.Description, Icon: work.Icon}
 		worksRes = append(worksRes, newWorkRes)
 	}
 

--- a/app/interfaces/response/work.go
+++ b/app/interfaces/response/work.go
@@ -26,7 +26,6 @@ type (
 		WorkID      string `json:"workID"`
 		Title       string `json:"title"`
 		Thumbnail   string `json:"thumbnail"`
-		Image       string `json:"image"`
 		Description string `json:"description"`
 		Icon        string `json:"icon"`
 	}

--- a/app/usecase/work.go
+++ b/app/usecase/work.go
@@ -27,6 +27,7 @@ func (w *WorkUseCase) CreateWork(r request.CreateWorkRequest, userId string) (st
 		ID:          workId,
 		Title:       r.Title,
 		Description: r.Description,
+		Thumbnail:   r.Thumbnail,
 		WorkUrl:     r.WorkUrl,
 		MovieUrl:    r.MovieUrl,
 		Security:    r.Security,
@@ -73,10 +74,12 @@ func (w *WorkUseCase) ReadWork(workID string) (*entity.ReadWork, *entity.User, e
 	if err != nil {
 		return nil, nil, err
 	}
+
 	user, err := w.workRepository.SelectWorkUser(work.UserId)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	return work, user, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module backend
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -675,9 +675,9 @@ components:
           type: string
           description: タイトル
           example: hoge
-        image:
+        thumbnail:
           type: object
-          description: 画像
+          description: サムネイル
           example: https://pbs.twimg.com/profile_images/1380218148649984001/27Mwc0-G_400x400.jpg
         description:
           type: string


### PR DESCRIPTION
### 概要

GET `/works/{number}`で受け取る記事が、imageの数だけ複製されていた
これを訂正し、代わりにthumbnailを入れた
かつレスポンスから不要となった"image"タグをなくした

### issue

#60