### PR TITLE
[fix]作品情報取得と一覧取得のresponseにuserIDを含める

### DIFF
--- a/app/domain/entity/work.go
+++ b/app/domain/entity/work.go
@@ -33,6 +33,7 @@ type (
 	}
 	ReadWorksList struct {
 		WorkID      string `db:"id"`
+		UserId      string `db:"user_id"`
 		Title       string `db:"title"`
 		Thumbnail   string `db:"thumbnail"`
 		Description string `db:"description"`

--- a/app/domain/entity/work.go
+++ b/app/domain/entity/work.go
@@ -34,6 +34,7 @@ type (
 	ReadWorksList struct {
 		WorkID      string `db:"id"`
 		UserId      string `db:"user_id"`
+		DisplayName string `db:"display_name"`
 		Title       string `db:"title"`
 		Thumbnail   string `db:"thumbnail"`
 		Description string `db:"description"`

--- a/app/infrastructure/work.go
+++ b/app/infrastructure/work.go
@@ -49,7 +49,7 @@ func (ur *workRepositoryImpl) SelectWorks(numberOfWorks uint) (*[]*entity.ReadWo
 	works := new([]*entity.ReadWorksList)
 	err := ur.db.Select(
 		works,
-		"SELECT works.id, works.user_id, works.title, works.description, works.thumbnail, users.icon FROM works INNER JOIN users ON works.user_id = users.id ORDER BY works.created_at DESC LIMIT ?",
+		"SELECT works.id, works.user_id, users.display_name, works.title, works.description, works.thumbnail, users.icon FROM works INNER JOIN users ON works.user_id = users.id ORDER BY works.created_at DESC LIMIT ?",
 		numberOfWorks)
 	if err != nil {
 		return nil, err

--- a/app/infrastructure/work.go
+++ b/app/infrastructure/work.go
@@ -49,7 +49,7 @@ func (ur *workRepositoryImpl) SelectWorks(numberOfWorks uint) (*[]*entity.ReadWo
 	works := new([]*entity.ReadWorksList)
 	err := ur.db.Select(
 		works,
-		"SELECT works.id, works.title, works.description, works.thumbnail, users.icon FROM works INNER JOIN users ON works.user_id = users.id ORDER BY works.created_at DESC LIMIT ?",
+		"SELECT works.id, works.user_id, works.title, works.description, works.thumbnail, users.icon FROM works INNER JOIN users ON works.user_id = users.id ORDER BY works.created_at DESC LIMIT ?",
 		numberOfWorks)
 	if err != nil {
 		return nil, err

--- a/app/interfaces/handler/work.go
+++ b/app/interfaces/handler/work.go
@@ -96,6 +96,7 @@ func (h *WorkHandler) ReadWork(w http.ResponseWriter, r *http.Request) {
 		Thumbnail:   raw.Thumbnail,
 		UserIcon:    user.Icon,
 		UserName:    user.DisplayName,
+		WorkUserID:  raw.UserId,
 		Images:      images,
 		WorkUrl:     raw.WorkUrl,
 		MovieUrl:    raw.MovieUrl,
@@ -135,7 +136,7 @@ func (h *WorkHandler) ReadWorks(w http.ResponseWriter, r *http.Request) {
 
 	worksRes := []response.ReadWorks{}
 	for _, work := range *works {
-		newWorkRes := response.ReadWorks{WorkID: work.WorkID, Title: work.Title, Thumbnail: work.Thumbnail, Description: work.Description, Icon: work.Icon}
+		newWorkRes := response.ReadWorks{WorkID: work.WorkID, WorkUserID: work.UserId, Title: work.Title, Thumbnail: work.Thumbnail, Description: work.Description, Icon: work.Icon}
 		worksRes = append(worksRes, newWorkRes)
 	}
 

--- a/app/interfaces/handler/work.go
+++ b/app/interfaces/handler/work.go
@@ -136,7 +136,7 @@ func (h *WorkHandler) ReadWorks(w http.ResponseWriter, r *http.Request) {
 
 	worksRes := []response.ReadWorks{}
 	for _, work := range *works {
-		newWorkRes := response.ReadWorks{WorkID: work.WorkID, WorkUserID: work.UserId, Title: work.Title, Thumbnail: work.Thumbnail, Description: work.Description, Icon: work.Icon}
+		newWorkRes := response.ReadWorks{WorkID: work.WorkID, WorkUserID: work.UserId, UserName: work.DisplayName, Title: work.Title, Thumbnail: work.Thumbnail, Description: work.Description, Icon: work.Icon}
 		worksRes = append(worksRes, newWorkRes)
 	}
 

--- a/app/interfaces/response/work.go
+++ b/app/interfaces/response/work.go
@@ -26,6 +26,7 @@ type (
 	ReadWorks struct {
 		WorkID      string `json:"workID"`
 		WorkUserID  string `json:"userID"`
+		UserName    string `json:"user_name"`
 		Title       string `json:"title"`
 		Thumbnail   string `json:"thumbnail"`
 		Description string `json:"description"`

--- a/app/interfaces/response/work.go
+++ b/app/interfaces/response/work.go
@@ -16,6 +16,7 @@ type (
 		Thumbnail   string  `json:"thumbnail"`
 		UserIcon    string  `json:"user_icon"`
 		UserName    string  `json:"user_name"`
+		WorkUserID  string  `json:"userID"`
 		Images      []Image `json:"images"`
 		WorkUrl     string  `json:"work_url"`
 		MovieUrl    string  `json:"movie_url"`
@@ -24,6 +25,7 @@ type (
 	}
 	ReadWorks struct {
 		WorkID      string `json:"workID"`
+		WorkUserID  string `json:"userID"`
 		Title       string `json:"title"`
 		Thumbnail   string `json:"thumbnail"`
 		Description string `json:"description"`

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -638,6 +638,10 @@ components:
           type: string
           description: ユーザ名
           example: FUN太郎
+        userID:
+          type: string
+          description: 作品を投稿したユーザのID
+          example: aohf93q4
         images:
           type: array
           items:
@@ -679,6 +683,10 @@ components:
           type: string
           description: 作品ID
           example: nb7890rwfbnvskd
+        userID:
+          type: string
+          description: 作品を投稿したユーザのID
+          example: oahf9023
         title:
           type: string
           description: タイトル

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -687,6 +687,10 @@ components:
           type: string
           description: 作品を投稿したユーザのID
           example: oahf9023
+        user_name:
+          type: string
+          description: 作品を投稿したユーザの表示名
+          example: FUN太朗
         title:
           type: string
           description: タイトル


### PR DESCRIPTION
## 機能概要
- 作品画面からユーザページに遷移するために作品情報取得APIと作品一覧取得APIのresponseにuserIDを含める
## issue
https://github.com/Funcy-ICT/Funcy_Portfolio_Backend/issues/100
## やったこと
- レスポンスにuserIDを含める
- swaggerを更新

## 確認したこと
responseにuserIDが含まれている
作品情報取得
![image](https://github.com/Funcy-ICT/Funcy_Portfolio_Backend/assets/49856793/a87b11eb-e76a-4984-bf89-1f5ab144e7a7)


作品一覧取得
![image](https://github.com/Funcy-ICT/Funcy_Portfolio_Backend/assets/49856793/fd053bb2-443a-4a51-9187-e07188edf489)

