### PR TITLE
[fix] commentテーブルの整合性を修正

### DIFF
--- a/db/migration/sql/20240701062632_create_comments_table.up.sql
+++ b/db/migration/sql/20240701062632_create_comments_table.up.sql
@@ -1,11 +1,11 @@
 CREATE TABLE `comment` (
-  `id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL COMMENT 'コメントID',
-  `user_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL COMMENT 'ユーザーID',
-  `works_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL COMMENT '作品ID',
-  `content` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL COMMENT '本文',
+  `id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'コメントID',
+  `user_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'ユーザーID',
+  `works_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '作品ID',
+  `content` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '本文',
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時',
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
   PRIMARY KEY (`id`),
   KEY `fk_comment_works` (`works_id`),
   CONSTRAINT `fk_comment_works` FOREIGN KEY (`works_id`) REFERENCES `works` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/db/migration/sql/20240701062632_create_comments_table.up.sql
+++ b/db/migration/sql/20240701062632_create_comments_table.up.sql
@@ -1,9 +1,11 @@
 CREATE TABLE `comment` (
-  `id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'コメントID',
-  `user_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'ユーザーID',
-  `works_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '作品ID',
-  `text` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '本文',
+  `id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL COMMENT 'コメントID',
+  `user_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL COMMENT 'ユーザーID',
+  `works_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL COMMENT '作品ID',
+  `content` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL COMMENT '本文',
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時',
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  PRIMARY KEY (`id`),
+  KEY `fk_comment_works` (`works_id`),
+  CONSTRAINT `fk_comment_works` FOREIGN KEY (`works_id`) REFERENCES `works` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;


### PR DESCRIPTION
### やったこと
- `works_id` の型変更と制約追加
- `text` カラムを `content` に名前変更
- ~~`utf8mb4_unicode_ci` を `utf8mb4_0900_ai_ci` に変更~~
- 外部キー制約の追加