### PR TITLE
[fix] DBエラーメッセージ露出を防止

### DIFF
--- a/app/interfaces/handler/auth.go
+++ b/app/interfaces/handler/auth.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -26,18 +27,21 @@ func (h *AuthHandler) SignUp(w http.ResponseWriter, r *http.Request) {
 	var req request.SignUpRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "bad request")
+		log.Printf("SignUp failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 	me, _ := utils.Validate(req)
 	if me != nil {
-		_ = response.ReturnValidationErrorResponse(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest), me)
+		log.Printf("SignUp failed: %v", me)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
 	userID, err := h.authUseCase.CreateAccount(req)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, err.Error())
+		log.Printf("SignUp failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -46,7 +50,8 @@ func (h *AuthHandler) SignUp(w http.ResponseWriter, r *http.Request) {
 	}
 	resBody, err := json.Marshal(res)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
+		log.Printf("SignUp failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -60,18 +65,21 @@ func (h *AuthHandler) SignIn(w http.ResponseWriter, r *http.Request) {
 	var req request.SignInRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "bad request")
+		log.Printf("SignIn failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 	me, _ := utils.Validate(req)
 	if me != nil {
-		_ = response.ReturnValidationErrorResponse(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest), me)
+		log.Printf("SignIn failed: %v", me)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
 	user, token, err := h.authUseCase.Login(req)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
+		log.Printf("SignIn failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -89,7 +97,8 @@ func (h *AuthHandler) SignIn(w http.ResponseWriter, r *http.Request) {
 
 	resBody, err := json.Marshal(res)
 	if err != nil {
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		log.Printf("SignIn failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -103,18 +112,21 @@ func (h *AuthHandler) SignInMobile(w http.ResponseWriter, r *http.Request) {
 	var req request.SignInRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "bad request")
+		log.Printf("SignInMobile failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 	me, _ := utils.Validate(req)
 	if me != nil {
-		_ = response.ReturnValidationErrorResponse(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest), me)
+		log.Printf("SignInMobile failed: %v", me)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
 	user, token, err := h.authUseCase.LoginMobile(req)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
+		log.Printf("SignInMobile failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -124,7 +136,8 @@ func (h *AuthHandler) SignInMobile(w http.ResponseWriter, r *http.Request) {
 	}
 	resBody, err := json.Marshal(res)
 	if err != nil {
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		log.Printf("SignInMobile failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -138,18 +151,22 @@ func (h *AuthHandler) AuthCode(w http.ResponseWriter, r *http.Request) {
 	var req request.AuthCodeRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "bad request")
+		log.Printf("AuthCode failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
+
 	me, _ := utils.Validate(req)
 	if me != nil {
-		_ = response.ReturnValidationErrorResponse(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest), me)
+		log.Printf("AuthCode failed: %v", me)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
 	err = h.authUseCase.CheckMail(req)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
+		log.Printf("AuthCode failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -169,7 +186,8 @@ func (h *AuthHandler) AuthCode(w http.ResponseWriter, r *http.Request) {
 	}
 	resBody, err := json.Marshal(res)
 	if err != nil {
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		log.Printf("AuthCode failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 

--- a/app/interfaces/handler/comment.go
+++ b/app/interfaces/handler/comment.go
@@ -29,15 +29,16 @@ func (h *CommentHandler) GetComment(w http.ResponseWriter, r *http.Request) {
 
 	comments, err := h.commentUseCase.GetComment(workID)
 	if err != nil {
-		log.Println(err)
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
+		log.Printf("GetComment failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
 	// create response
 	resBody, err := json.Marshal(comments)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, err.Error())
+		log.Printf("GetComment failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -50,19 +51,22 @@ func (h *CommentHandler) CreateComment(w http.ResponseWriter, r *http.Request) {
 	var req request.CreateCommentRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "bad request")
+		log.Printf("CreateComment failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
 	me, _ := utils.Validate(req)
 	if me != nil {
+		log.Printf("CreateComment failed: validation error: %v", me)
 		_ = response.ReturnValidationErrorResponse(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest), me)
 		return
 	}
 
 	commentID, err := h.commentUseCase.CreateComment(req.UserID, req.WorksID, req.Content)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, err.Error())
+		log.Printf("CreateComment failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -74,7 +78,8 @@ func (h *CommentHandler) CreateComment(w http.ResponseWriter, r *http.Request) {
 
 	resBody, err := json.Marshal(res)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
+		log.Printf("CreateComment failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
 		return
 	}
 

--- a/app/interfaces/handler/group.go
+++ b/app/interfaces/handler/group.go
@@ -6,6 +6,7 @@ import (
 	"backend/app/packages/utils"
 	"backend/app/usecase"
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 )
@@ -26,19 +27,22 @@ func (h *GroupHandler) CreateGroup(w http.ResponseWriter, r *http.Request) {
 	err := json.NewDecoder(r.Body).Decode(&req)
 
 	if err != nil {
+		log.Printf("CreateGroup failed: %v", err)
 		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "bad request")
 		return
 	}
 
 	me, _ := utils.Validate(req)
 	if me != nil {
+		log.Printf("CreateGroup failed: validation error: %v", me)
 		_ = response.ReturnValidationErrorResponse(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest), me)
 		return
 	}
 
 	groupID, err := h.groupUseCase.CreateGroup(req.Name, req.Description, req.LeaderEmail, req.Icon, req.GroupSkills)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, err.Error())
+		log.Printf("CreateGroup failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -48,7 +52,8 @@ func (h *GroupHandler) CreateGroup(w http.ResponseWriter, r *http.Request) {
 
 	resBody, err := json.Marshal(res)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
+		log.Printf("CreateGroup failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 

--- a/app/interfaces/handler/userinfo.go
+++ b/app/interfaces/handler/userinfo.go
@@ -30,8 +30,8 @@ func (h *UserinfoHandler) GetUserinfo(w http.ResponseWriter, r *http.Request) {
 	// do
 	userinfo, works, err := h.userinfoUseCase.GetUserinfo(userID)
 	if err != nil {
-		log.Println(err)
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
+		log.Printf("GetUserinfo failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -71,7 +71,9 @@ func (h *UserinfoHandler) GetUserinfo(w http.ResponseWriter, r *http.Request) {
 
 	resBody, err := json.Marshal(res)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, err.Error())
+		log.Printf("GetUserinfo failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -86,24 +88,28 @@ func (h *UserinfoHandler) PutUserinfo(w http.ResponseWriter, r *http.Request) {
 	var req request.UpdateUserInfo
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "bad request")
+		log.Printf("PutUserinfo failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
 	ve, _ := utils.Validate(req)
 	if ve != nil {
+		log.Printf("PutUserinfo failed: validation error: %v", ve)
 		_ = response.ReturnValidationErrorResponse(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest), ve)
 		return
 	}
 
 	if err := h.userinfoUseCase.UpdateUserinfo(userID, &req); err != nil {
-		response.ReturnErrorResponse(w, http.StatusInternalServerError, err.Error())
+		log.Printf("PutUserinfo failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
+		return
 	}
 
 	userinfo, works, err := h.userinfoUseCase.GetUserinfo(userID)
 	if err != nil {
-		log.Println(err)
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
+		log.Printf("PutUserinfo failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -143,7 +149,9 @@ func (h *UserinfoHandler) PutUserinfo(w http.ResponseWriter, r *http.Request) {
 
 	resBody, err := json.Marshal(res)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, err.Error())
+		log.Printf("PutUserinfo failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/app/interfaces/handler/work.go
+++ b/app/interfaces/handler/work.go
@@ -6,6 +6,7 @@ import (
 	"backend/app/packages/utils"
 	"backend/app/usecase"
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -62,7 +63,8 @@ func (h *WorkHandler) CreateWork(w http.ResponseWriter, r *http.Request) {
 	)
 
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, err.Error())
+		log.Printf("CreateWork failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -72,7 +74,8 @@ func (h *WorkHandler) CreateWork(w http.ResponseWriter, r *http.Request) {
 
 	resBody, err := json.Marshal(res)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
+		log.Printf("CreateWork failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -83,16 +86,17 @@ func (h *WorkHandler) CreateWork(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *WorkHandler) ReadWork(w http.ResponseWriter, r *http.Request) {
-
 	workID := strings.TrimPrefix(r.URL.Path, "/work/")
 	if workID == "" {
+		log.Printf("ReadWork failed: workID is empty")
 		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "bad request")
 		return
 	}
 
 	raw, user, err := h.workUseCase.ReadWork(workID)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
+		log.Printf("ReadWork failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -127,7 +131,8 @@ func (h *WorkHandler) ReadWork(w http.ResponseWriter, r *http.Request) {
 
 	resBody, err := json.Marshal(res)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
+		log.Printf("ReadWork failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -154,7 +159,9 @@ func (h *WorkHandler) ReadWorks(w http.ResponseWriter, r *http.Request) {
 
 	works, err := h.workUseCase.ReadWorks(numberOfWorks, tag)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, err.Error())
+		log.Printf("ReadWorks failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
+		return
 	}
 
 	worksRes := []response.ReadWorks{}
@@ -169,7 +176,9 @@ func (h *WorkHandler) ReadWorks(w http.ResponseWriter, r *http.Request) {
 
 	resBody, err := json.Marshal(res)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, err.Error())
+		log.Printf("ReadWorks failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -183,8 +192,8 @@ func (h *WorkHandler) DeleteWork(w http.ResponseWriter, r *http.Request) {
 
 	err := h.workUseCase.DeleteWork(workID)
 	if err != nil {
-		e := response.UnwrapError(err)
-		_ = response.ReturnErrorResponse(w, e.Code, e.Message)
+		log.Printf("DeleteWork failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -194,7 +203,8 @@ func (h *WorkHandler) DeleteWork(w http.ResponseWriter, r *http.Request) {
 
 	resBody, err := json.Marshal(res)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
+		log.Printf("DeleteWork failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -208,11 +218,13 @@ func (h *WorkHandler) UpdateWork(w http.ResponseWriter, r *http.Request) {
 	var req request.UpdateWorkRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "bad request")
+		log.Printf("UpdateWork failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "An unexpected error occurred. Please try again later.")
 		return
 	}
 	me, _ := utils.Validate(req)
 	if me != nil {
+		log.Printf("UpdateWork failed: validation error: %v", me)
 		_ = response.ReturnValidationErrorResponse(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest), me)
 		return
 	}
@@ -241,8 +253,8 @@ func (h *WorkHandler) UpdateWork(w http.ResponseWriter, r *http.Request) {
 		tags,
 	)
 	if err != nil {
-		e := response.UnwrapError(err)
-		_ = response.ReturnErrorResponse(w, e.Code, e.Message)
+		log.Printf("UpdateWork failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
 		return
 	}
 
@@ -252,7 +264,8 @@ func (h *WorkHandler) UpdateWork(w http.ResponseWriter, r *http.Request) {
 
 	resBody, err := json.Marshal(res)
 	if err != nil {
-		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, err.Error())
+		log.Printf("UpdateWork failed: %v", err)
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, "An unexpected error occurred. Please try again later.")
 		return
 	}
 

--- a/app/usecase/auth.go
+++ b/app/usecase/auth.go
@@ -7,6 +7,7 @@ import (
 	"backend/app/packages/utils"
 	"backend/app/packages/utils/auth"
 	"backend/app/packages/utils/mail"
+	"fmt"
 	"math/rand"
 	"strconv"
 	"time"
@@ -78,11 +79,11 @@ func (a *AuthUseCase) CreateAccount(r request.SignUpRequest) (string, error) {
 func (a *AuthUseCase) Login(r request.SignInRequest) (*entity.User, string, error) {
 	user, err := a.authRepository.GetPassword(r.Mail)
 	if err != nil {
-		return nil, "", errors.New("not match email")
+		return nil, "", fmt.Errorf("not match email: %w", err)
 	}
 	err = utils.CompareHashAndPassword(user.Password, r.Password)
 	if err != nil {
-		return nil, "", errors.New("not match password")
+		return nil, "", fmt.Errorf("not match password: %w", err)
 	}
 
 	jwt, _ := auth.IssueUserToken(user.UserID)
@@ -92,11 +93,11 @@ func (a *AuthUseCase) Login(r request.SignInRequest) (*entity.User, string, erro
 func (a *AuthUseCase) LoginMobile(r request.SignInRequest) (*entity.User, string, error) {
 	user, err := a.authRepository.GetPassword(r.Mail)
 	if err != nil {
-		return nil, "", errors.New("not match email")
+		return nil, "", fmt.Errorf("not match email: %w", err)
 	}
 	err = utils.CompareHashAndPassword(user.Password, r.Password)
 	if err != nil {
-		return nil, "", errors.New("not match password")
+		return nil, "", fmt.Errorf("not match password: %w", err)
 	}
 
 	jwt, _ := auth.IssueMobileUserToken(user.UserID)
@@ -107,14 +108,14 @@ func (a *AuthUseCase) CheckMail(r request.AuthCodeRequest) error {
 
 	code, err := a.authRepository.CheckMailAddr(r.UserID)
 	if err != nil {
-		return errors.New("not match email")
+		return fmt.Errorf("not match email: %w", err)
 	}
 	if code != r.Code {
-		return errors.New("not match code")
+		return fmt.Errorf("not match code: %w", err)
 	}
 	err = a.authRepository.UpdateStatus(r.UserID)
 	if code != r.Code {
-		return errors.New("not match code")
+		return fmt.Errorf("not match code: %w", err)
 	}
 
 	return nil

--- a/app/usecase/auth.go
+++ b/app/usecase/auth.go
@@ -78,7 +78,7 @@ func (a *AuthUseCase) CreateAccount(r request.SignUpRequest) (string, error) {
 func (a *AuthUseCase) Login(r request.SignInRequest) (*entity.User, string, error) {
 	user, err := a.authRepository.GetPassword(r.Mail)
 	if err != nil {
-		return nil, "", err
+		return nil, "", errors.New("not match email")
 	}
 	err = utils.CompareHashAndPassword(user.Password, r.Password)
 	if err != nil {
@@ -92,7 +92,7 @@ func (a *AuthUseCase) Login(r request.SignInRequest) (*entity.User, string, erro
 func (a *AuthUseCase) LoginMobile(r request.SignInRequest) (*entity.User, string, error) {
 	user, err := a.authRepository.GetPassword(r.Mail)
 	if err != nil {
-		return nil, "", err
+		return nil, "", errors.New("not match email")
 	}
 	err = utils.CompareHashAndPassword(user.Password, r.Password)
 	if err != nil {
@@ -107,14 +107,14 @@ func (a *AuthUseCase) CheckMail(r request.AuthCodeRequest) error {
 
 	code, err := a.authRepository.CheckMailAddr(r.UserID)
 	if err != nil {
-		return err
+		return errors.New("not match email")
 	}
 	if code != r.Code {
 		return errors.New("not match code")
 	}
 	err = a.authRepository.UpdateStatus(r.UserID)
 	if code != r.Code {
-		return err
+		return errors.New("not match code")
 	}
 
 	return nil

--- a/app/usecase/comment.go
+++ b/app/usecase/comment.go
@@ -3,7 +3,7 @@ package usecase
 import (
 	"backend/app/domain/entity"
 	"backend/app/domain/repository"
-	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -36,7 +36,7 @@ func (u *CommentUseCase) CreateComment(userID, worksID, content string) (string,
 	}
 	err := u.commentRepository.InsertComment(comment)
 	if err != nil {
-		return "", errors.New("failed to insert comment")
+		return "", fmt.Errorf("failed to insert comment: %w", err)
 	}
 	return comment.ID, nil
 }

--- a/app/usecase/comment.go
+++ b/app/usecase/comment.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"backend/app/domain/entity"
 	"backend/app/domain/repository"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -35,7 +36,7 @@ func (u *CommentUseCase) CreateComment(userID, worksID, content string) (string,
 	}
 	err := u.commentRepository.InsertComment(comment)
 	if err != nil {
-		return "", err
+		return "", errors.New("failed to insert comment")
 	}
 	return comment.ID, nil
 }

--- a/app/usecase/group.go
+++ b/app/usecase/group.go
@@ -3,7 +3,7 @@ package usecase
 import (
 	"backend/app/domain/entity"
 	"backend/app/domain/repository"
-	"errors"
+	"fmt"
 )
 
 type GroupUseCase struct {
@@ -26,7 +26,7 @@ func (u *GroupUseCase) CreateGroup(name string, description string, leaderEmail 
 
 	err = u.groupRepository.InsertGroup(group, &groupSkillsEntity)
 	if err != nil {
-		return "", errors.New("failed to insert group")
+		return "", fmt.Errorf("failed to insert group: %w", err)
 	}
 	return group.GroupID, nil
 }

--- a/app/usecase/group.go
+++ b/app/usecase/group.go
@@ -3,7 +3,7 @@ package usecase
 import (
 	"backend/app/domain/entity"
 	"backend/app/domain/repository"
-	"fmt"
+	"errors"
 )
 
 type GroupUseCase struct {
@@ -26,7 +26,7 @@ func (u *GroupUseCase) CreateGroup(name string, description string, leaderEmail 
 
 	err = u.groupRepository.InsertGroup(group, &groupSkillsEntity)
 	if err != nil {
-		return "", fmt.Errorf("failed to insert group: %w", err)
+		return "", errors.New("failed to insert group")
 	}
 	return group.GroupID, nil
 }

--- a/app/usecase/userinfo.go
+++ b/app/usecase/userinfo.go
@@ -4,6 +4,7 @@ import (
 	"backend/app/domain/entity"
 	"backend/app/domain/repository"
 	"backend/app/interfaces/request"
+	"errors"
 )
 
 type UserinfoUseCase struct {
@@ -24,15 +25,15 @@ func NewUserinfoUsecace(
 func (u *UserinfoUseCase) GetUserinfo(userID string) (*entity.Userinfo, *[]*entity.ReadWorksList, error) {
 	userinfo, err := u.userinfoRepository.SelectUserinfoByUserID(userID)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.New("failed to get userinfo")
 	}
 
 	works, err := u.workRepository.SelectWorksByUserID(userID)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.New("failed to get works")
 	}
 
-	return userinfo, works, err
+	return userinfo, works, nil
 }
 
 func (u *UserinfoUseCase) UpdateUserinfo(userID string, userinfo *request.UpdateUserInfo) error {

--- a/app/usecase/userinfo.go
+++ b/app/usecase/userinfo.go
@@ -4,7 +4,7 @@ import (
 	"backend/app/domain/entity"
 	"backend/app/domain/repository"
 	"backend/app/interfaces/request"
-	"errors"
+	"fmt"
 )
 
 type UserinfoUseCase struct {
@@ -25,12 +25,12 @@ func NewUserinfoUsecace(
 func (u *UserinfoUseCase) GetUserinfo(userID string) (*entity.Userinfo, *[]*entity.ReadWorksList, error) {
 	userinfo, err := u.userinfoRepository.SelectUserinfoByUserID(userID)
 	if err != nil {
-		return nil, nil, errors.New("failed to get userinfo")
+		return nil, nil, fmt.Errorf("failed to get userinfo: %w", err)
 	}
 
 	works, err := u.workRepository.SelectWorksByUserID(userID)
 	if err != nil {
-		return nil, nil, errors.New("failed to get works")
+		return nil, nil, fmt.Errorf("failed to get works: %w", err)
 	}
 
 	return userinfo, works, nil

--- a/app/usecase/work.go
+++ b/app/usecase/work.go
@@ -4,6 +4,7 @@ import (
 	"backend/app/domain/entity"
 	"backend/app/domain/repository"
 	"errors"
+	"fmt"
 )
 
 type WorkUseCase struct {
@@ -126,7 +127,7 @@ func (w *WorkUseCase) UpdateWork(
 
 	err := w.workRepository.UpdateWork(&work, &imagesEntity, &tagsEntity)
 	if err != nil {
-		return errors.New("failed to update work")
+		return fmt.Errorf("failed to update work: %w", err)
 	}
 
 	return nil

--- a/app/usecase/work.go
+++ b/app/usecase/work.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"backend/app/domain/entity"
 	"backend/app/domain/repository"
+	"errors"
 )
 
 type WorkUseCase struct {
@@ -48,7 +49,7 @@ func (w *WorkUseCase) CreateWork(
 
 	err := w.workRepository.InsertWork(userId, &work, &imagesEntity, &tagsEntity)
 	if err != nil {
-		return "", err
+		return "", errors.New("failed to insert work")
 	}
 
 	return work.ID, nil
@@ -58,14 +59,14 @@ func (w *WorkUseCase) ReadWorks(numberOfWorks uint, tag string) (*[]*entity.Read
 	if len(tag) == 0 {
 		works, err := w.workRepository.SelectWorks(numberOfWorks)
 		if err != nil {
-			return &[]*entity.ReadWorksList{}, err
+			return &[]*entity.ReadWorksList{}, errors.New("failed to get works")
 		}
 
 		return works, nil
 	} else {
 		works, err := w.workRepository.SelectWorksByTag(numberOfWorks, tag)
 		if err != nil {
-			return &[]*entity.ReadWorksList{}, err
+			return &[]*entity.ReadWorksList{}, errors.New("failed to get works by tag")
 		}
 
 		return works, nil
@@ -75,12 +76,12 @@ func (w *WorkUseCase) ReadWorks(numberOfWorks uint, tag string) (*[]*entity.Read
 func (w *WorkUseCase) ReadWork(workID string) (*entity.ReadWork, *entity.User, error) {
 	work, err := w.workRepository.SelectWork(workID)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.New("failed to get work")
 	}
 
 	user, err := w.workRepository.SelectWorkUser(work.UserId)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, errors.New("failed to get work by user")
 	}
 
 	return work, user, nil
@@ -125,7 +126,7 @@ func (w *WorkUseCase) UpdateWork(
 
 	err := w.workRepository.UpdateWork(&work, &imagesEntity, &tagsEntity)
 	if err != nil {
-		return err
+		return errors.New("failed to update work")
 	}
 
 	return nil


### PR DESCRIPTION
### 概要
エラーメッセージがユーザーに露出しないように修正
簡易的に以下のルールに則って修正しています．

### ユースケース層
処理中に発生したエラーを出力

```
// example
// optional
//var (
//    ErrUserNotFound = errors.New("user not found")
//)

return nil, errors.New("user not found")
```
### interface層
ユーザーに見せるメッセージ
```
// example
http.Error(w, "ユーザーが見つかりませんでした", http.StatusNotFound)
http.Error(w, "内部エラーが発生しました", http.StatusInternalServerError)
```

### その他
他の層にもルールを設けるべき，現在の書き方の修正案があればコメントください！
