### PR TITLE
[feat]プロフィール画像削除とコース情報対応

### DIFF
--- a/app/domain/entity/userinfo.go
+++ b/app/domain/entity/userinfo.go
@@ -5,6 +5,7 @@ type Userinfo struct {
 	JoinedGroups *[]*GroupMember
 	Skills       *[]*Skill
 	SNS          *[]*SNS
+	Course       string
 }
 
 type UpdateUserinfo struct {

--- a/app/domain/entity/work.go
+++ b/app/domain/entity/work.go
@@ -31,6 +31,7 @@ type (
 		Thumbnail   string `db:"thumbnail"`
 		Description string `db:"description"`
 		Icon        string `db:"icon"`
+		Security    int    `db:"security"`
 	}
 	InsertWork struct {
 		ID          string `db:"id"`

--- a/app/infrastructure/userinfo.go
+++ b/app/infrastructure/userinfo.go
@@ -148,7 +148,7 @@ func (ur *userinfoRepositoryImpl) UpdateUserinfo(userinfo *entity.UpdateUserinfo
 		// user profile
 		{
 			_, err := tx.NamedExec(
-				"UPDATE user_profile SET user_id=:user_id, header_image=:header_image, bio=:bio;",
+				"UPDATE user_profile SET header_image=:header_image, bio=:bio WHERE user_id=:user_id;",
 				userinfo.Profile,
 			)
 			if err != nil {
@@ -157,13 +157,14 @@ func (ur *userinfoRepositoryImpl) UpdateUserinfo(userinfo *entity.UpdateUserinfo
 			}
 		}
 
-		// user icon
+		// user icon and display_name
 		{
 			_, err := tx.NamedExec(
-				"UPDATE users SET icon=:icon WHERE id=:user_id;",
+				"UPDATE users SET icon=:icon, display_name=:display_name WHERE id=:user_id;",
 				map[string]interface{}{
-					"icon":    userinfo.Profile.Icon,
-					"user_id": userinfo.Profile.UserID,
+					"icon":         userinfo.Profile.Icon,
+					"display_name": userinfo.Profile.DisplayName,
+					"user_id":      userinfo.Profile.UserID,
 				},
 			)
 			if err != nil {

--- a/app/infrastructure/work.go
+++ b/app/infrastructure/work.go
@@ -90,7 +90,7 @@ func (ur *workRepositoryImpl) SelectWorksByUserID(userID string) (*[]*entity.Rea
 	works := new([]*entity.ReadWorksList)
 	err := ur.db.Select(
 		works,
-		"SELECT works.id, works.title, works.thumbnail, works.description, users.icon FROM works INNER JOIN users ON works.user_id = users.id WHERE works.user_id = ?;",
+		"SELECT works.id, works.title, works.thumbnail, works.description, users.icon FROM works INNER JOIN users ON works.user_id = users.id WHERE works.user_id = ? ORDER BY works.created_at DESC;",
 		userID)
 	if err != nil {
 		return nil, err

--- a/app/infrastructure/work.go
+++ b/app/infrastructure/work.go
@@ -51,7 +51,7 @@ func (ur *workRepositoryImpl) SelectWorks(numberOfWorks uint) (*[]*entity.ReadWo
 	works := new([]*entity.ReadWorksList)
 	err := ur.db.Select(
 		works,
-		"SELECT works.id, works.title, works.description, works.thumbnail, users.icon FROM works INNER JOIN users ON works.user_id = users.id WHERE works.security = 1 ORDER BY works.created_at DESC LIMIT ?",
+		"SELECT works.id, works.title, works.description, works.thumbnail, works.security, users.icon FROM works INNER JOIN users ON works.user_id = users.id WHERE works.security = 1 ORDER BY works.created_at DESC LIMIT ?",
 		numberOfWorks)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func (ur *workRepositoryImpl) SelectWorksByTag(numberOfWorks uint, tag string) (
 	works := new([]*entity.ReadWorksList)
 	err := ur.db.Select(
 		works,
-		"SELECT works.id, works.title, works.description, works.thumbnail, users.icon FROM works INNER JOIN work_images ON works.id = work_images.work_id INNER JOIN work_tags ON works.id = work_tags.work_id INNER JOIN users ON works.user_id = users.id WHERE work_tags.tag=? ORDER BY works.created_at DESC LIMIT ?",
+		"SELECT works.id, works.title, works.description, works.thumbnail, works.security, users.icon FROM works INNER JOIN work_images ON works.id = work_images.work_id INNER JOIN work_tags ON works.id = work_tags.work_id INNER JOIN users ON works.user_id = users.id WHERE work_tags.tag=? ORDER BY works.created_at DESC LIMIT ?",
 		tag,
 		numberOfWorks)
 	if err != nil {
@@ -90,7 +90,7 @@ func (ur *workRepositoryImpl) SelectWorksByUserID(userID string) (*[]*entity.Rea
 	works := new([]*entity.ReadWorksList)
 	err := ur.db.Select(
 		works,
-		"SELECT works.id, works.title, works.thumbnail, works.description, users.icon FROM works INNER JOIN users ON works.user_id = users.id WHERE works.user_id = ? ORDER BY works.created_at DESC;",
+		"SELECT works.id, works.title, works.thumbnail, works.description, works.security, users.icon FROM works INNER JOIN users ON works.user_id = users.id WHERE works.user_id = ? ORDER BY works.created_at DESC;",
 		userID)
 	if err != nil {
 		return nil, err
@@ -98,6 +98,7 @@ func (ur *workRepositoryImpl) SelectWorksByUserID(userID string) (*[]*entity.Rea
 
 	return works, nil
 }
+
 
 func (ur *workRepositoryImpl) SelectWork(workID string) (*entity.ReadWork, error) {
 	work := new(entity.ReadWork)

--- a/app/interfaces/handler/userinfo.go
+++ b/app/interfaces/handler/userinfo.go
@@ -66,6 +66,7 @@ func (h *UserinfoHandler) GetUserinfo(w http.ResponseWriter, r *http.Request) {
 		Group:           *group,
 		Skills:          *skills,
 		DisplayName:     userinfo.Profile.DisplayName,
+		Course:          userinfo.Course,
 		Works:           *worksRes,
 	}
 
@@ -138,6 +139,7 @@ func (h *UserinfoHandler) PutUserinfo(w http.ResponseWriter, r *http.Request) {
 		Group:           *group,
 		Skills:          *skills,
 		DisplayName:     userinfo.Profile.DisplayName,
+		Course:          userinfo.Course,
 		Works:           *worksRes,
 	}
 

--- a/app/interfaces/handler/work.go
+++ b/app/interfaces/handler/work.go
@@ -159,7 +159,7 @@ func (h *WorkHandler) ReadWorks(w http.ResponseWriter, r *http.Request) {
 
 	worksRes := []response.ReadWorks{}
 	for _, work := range *works {
-		newWorkRes := response.ReadWorks{WorkID: work.WorkID, Title: work.Title, Thumbnail: work.Thumbnail, Description: work.Description, Icon: work.Icon}
+		newWorkRes := response.ReadWorks{WorkID: work.WorkID, Title: work.Title, Thumbnail: work.Thumbnail, Description: work.Description, Icon: work.Icon, Security: work.Security}
 		worksRes = append(worksRes, newWorkRes)
 	}
 
@@ -277,7 +277,7 @@ func (h *WorkHandler) ReadWorksByUser(w http.ResponseWriter, r *http.Request) {
 
 	worksRes := []response.ReadWorks{}
 	for _, work := range *works {
-		newWorkRes := response.ReadWorks{WorkID: work.WorkID, Title: work.Title, Thumbnail: work.Thumbnail, Description: work.Description, Icon: work.Icon}
+		newWorkRes := response.ReadWorks{WorkID: work.WorkID, Title: work.Title, Thumbnail: work.Thumbnail, Description: work.Description, Icon: work.Icon, Security: work.Security}
 		worksRes = append(worksRes, newWorkRes)
 	}
 
@@ -296,3 +296,39 @@ func (h *WorkHandler) ReadWorksByUser(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(resBody)
 }
+
+func (h *WorkHandler) ReadWorksByUserID(w http.ResponseWriter, r *http.Request) {
+	userID := chi.URLParam(r, "userID")
+	if userID == "" {
+		_ = response.ReturnErrorResponse(w, http.StatusBadRequest, "user ID is required")
+		return
+	}
+
+	works, err := h.workUseCase.ReadWorksByUserID(userID)
+	if err != nil {
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	worksRes := []response.ReadWorks{}
+	for _, work := range *works {
+		newWorkRes := response.ReadWorks{WorkID: work.WorkID, Title: work.Title, Thumbnail: work.Thumbnail, Description: work.Description, Icon: work.Icon, Security: work.Security}
+		worksRes = append(worksRes, newWorkRes)
+	}
+
+	res := response.ReadWorksList{
+		Works: worksRes,
+	}
+
+	resBody, err := json.Marshal(res)
+	if err != nil {
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", strconv.Itoa(len(resBody)))
+	w.WriteHeader(http.StatusOK)
+	w.Write(resBody)
+}
+

--- a/app/interfaces/handler/work.go
+++ b/app/interfaces/handler/work.go
@@ -261,3 +261,38 @@ func (h *WorkHandler) UpdateWork(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write(resBody)
 }
+
+func (h *WorkHandler) ReadWorksByUser(w http.ResponseWriter, r *http.Request) {
+	userID := r.Context().Value("user_id")
+	if userID == nil {
+		_ = response.ReturnErrorResponse(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	works, err := h.workUseCase.ReadWorksByUserID(userID.(string))
+	if err != nil {
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	worksRes := []response.ReadWorks{}
+	for _, work := range *works {
+		newWorkRes := response.ReadWorks{WorkID: work.WorkID, Title: work.Title, Thumbnail: work.Thumbnail, Description: work.Description, Icon: work.Icon}
+		worksRes = append(worksRes, newWorkRes)
+	}
+
+	res := response.ReadWorksList{
+		Works: worksRes,
+	}
+
+	resBody, err := json.Marshal(res)
+	if err != nil {
+		_ = response.ReturnErrorResponse(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Length", strconv.Itoa(len(resBody)))
+	w.WriteHeader(http.StatusOK)
+	w.Write(resBody)
+}

--- a/app/interfaces/response/userinfo.go
+++ b/app/interfaces/response/userinfo.go
@@ -8,5 +8,6 @@ type UserInfo struct {
 	Group           []string    `json:"group"`
 	Skills          []string    `json:"skills"`
 	DisplayName     string      `json:"displayName"`
+	Course          string      `json:"course"`
 	Works           []ReadWorks `json:"works"`
 }

--- a/app/interfaces/response/work.go
+++ b/app/interfaces/response/work.go
@@ -30,6 +30,7 @@ type (
 		Thumbnail   string `json:"thumbnail"`
 		Description string `json:"description"`
 		Icon        string `json:"icon"`
+		Security    int    `json:"security"`
 	}
 	ReadWorksList struct {
 		Works []ReadWorks `json:"works"`

--- a/app/interfaces/server.go
+++ b/app/interfaces/server.go
@@ -97,6 +97,9 @@ func (s *Server) Route() {
 			r.Put("/{workID}", workHandler.UpdateWork)
 		})
 
+		// ユーザー別作品取得エンドポイント
+		mux.Get("/user/works", workHandler.ReadWorksByUser)
+
 		// ユーザー情報関連のエンドポイント
 		mux.Route("/userinfo", func(r chi.Router) {
 			r.Get("/{userID}", userinfoHandler.GetUserinfo)

--- a/app/interfaces/server.go
+++ b/app/interfaces/server.go
@@ -119,5 +119,6 @@ func (s *Server) Route() {
 	// no auth
 	s.Router.Get("/work/{workID}", workHandler.ReadWork)
 	s.Router.Get("/works/{number}", workHandler.ReadWorks)
+	s.Router.Get("/user/{userID}/works", workHandler.ReadWorksByUserID)
 
 }

--- a/app/usecase/work.go
+++ b/app/usecase/work.go
@@ -130,3 +130,12 @@ func (w *WorkUseCase) UpdateWork(
 
 	return nil
 }
+
+func (w *WorkUseCase) ReadWorksByUserID(userID string) (*[]*entity.ReadWorksList, error) {
+	works, err := w.workRepository.SelectWorksByUserID(userID)
+	if err != nil {
+		return &[]*entity.ReadWorksList{}, err
+	}
+
+	return works, nil
+}

--- a/app/usecase/work.go
+++ b/app/usecase/work.go
@@ -139,3 +139,4 @@ func (w *WorkUseCase) ReadWorksByUserID(userID string) (*[]*entity.ReadWorksList
 
 	return works, nil
 }
+

--- a/file-server/pkg/controller/file.go
+++ b/file-server/pkg/controller/file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -69,4 +70,38 @@ func UploadImage() gin.HandlerFunc {
 		c.JSON(http.StatusOK, view.UploadResponse(urls))
 	}
 
+}
+
+func DeleteImage() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		fileName := c.Param("filename")
+
+		if fileName == "" {
+			view.ReturnErrorResponse(
+				c,
+				http.StatusBadRequest,
+				"Bad Request",
+				"filename is required",
+			)
+			return
+		}
+
+		// uploadimagesディレクトリから削除
+		filePath := fmt.Sprintf("uploadimages/%s", fileName)
+
+		err := os.Remove(filePath)
+		if err != nil {
+			log.Printf("[ERROR] Failed to delete file: %s, error: %v\n", filePath, err)
+			view.ReturnErrorResponse(
+				c,
+				http.StatusInternalServerError,
+				"Internal Server Error",
+				"Failed to delete file",
+			)
+			return
+		}
+
+		log.Printf("[INFO] Successfully deleted file: %s\n", filePath)
+		c.JSON(http.StatusOK, gin.H{"message": "File deleted successfully"})
+	}
 }

--- a/file-server/pkg/server.go
+++ b/file-server/pkg/server.go
@@ -20,4 +20,5 @@ func init() {
 
 	Server.Use(static.Serve("/", static.LocalFile("./uploadimages", true)))
 	Server.POST("/upload/file", controller.UploadImage())
+	Server.DELETE("/delete/:filename", controller.DeleteImage())
 }


### PR DESCRIPTION
### 概要
プロフィール画面での画像アップロード・削除機能の実装と，ユーザーのコース情報表示機能を追加しました

#### 解決した課題
1. プロフィール画像更新時に古いファイルが残る問題
2. ユーザーのコース情報がAPIで取得できない問題

### 修正内容
#### ファイルサーバー
- 画像削除エンドポイント: DELETE
/delete/:filename を追加
- ファイル削除: uploadimagesディレクトリからの画像ファイル削除処理を実装
- エラーハンドリング:削除失敗時の適切なレスポンス処理

#### userinfo API
- コース情報追加:APIレスポンスにcourseフィールドを追加
- データ取得拡張: usersテーブルからcourse情報を取得するようSQLクエリを修正
- エンティティ更新:Userinfoエンティティにコース情報を追加

#### データ構造変更
- entity.UserinfoにCourseフィールドを追加
- response.UserInfoにCourseフィールドを追加
- infrastructureレイヤーでusersテーブルとのJOIN処理を更新