### PR TITLE
fix: Cookie settings for cross-domain authentication

### DIFF
--- a/app/interfaces/handler/auth.go
+++ b/app/interfaces/handler/auth.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 
 	"backend/app/interfaces/request"
@@ -12,6 +13,11 @@ import (
 	"backend/app/packages/utils/auth"
 	"backend/app/usecase"
 )
+
+func isProduction() bool {
+	env := os.Getenv("ENVIRONMENT")
+	return env == "production"
+}
 
 type AuthHandler struct {
 	authUseCase *usecase.AuthUseCase
@@ -86,8 +92,13 @@ func (h *AuthHandler) SignIn(w http.ResponseWriter, r *http.Request) {
 	cookie := &http.Cookie{
 		Name:     "token",
 		Value:    token,
+		Path:     "/",
 		HttpOnly: true,
-		//Secure: true,
+		Secure:   isProduction(),
+		SameSite: http.SameSiteLax,
+	}
+	if isProduction() {
+		cookie.SameSite = http.SameSiteNone
 	}
 	http.SetCookie(w, cookie)
 
@@ -177,7 +188,11 @@ func (h *AuthHandler) AuthCode(w http.ResponseWriter, r *http.Request) {
 		Value:    jwt,
 		Path:     "/",
 		HttpOnly: true,
-		//Secure: true,
+		Secure:   isProduction(),
+		SameSite: http.SameSiteLax,
+	}
+	if isProduction() {
+		cookie.SameSite = http.SameSiteNone
 	}
 	http.SetCookie(w, cookie)
 


### PR DESCRIPTION
#### 変更内容:
- 本番環境でクロスドメインCookie送信を有効化
- Secure: true, SameSite: None を本番環境に適用
- ローカル開発環境では従来通り動作（Secure: false, SameSite: Lax）
- 環境判定は ENVIRONMENT=production 環境変数で実施

#### 影響:
- Firebase Hostingからの認証が正常に動作するようになる