### PR TITLE
GCSへアップロード時にContent type情報を追加

### DIFF
--- a/app/packages/storage/gcs.go
+++ b/app/packages/storage/gcs.go
@@ -33,11 +33,13 @@ func NewGCSClient(ctx context.Context) (*GCSClient, error) {
 }
 
 // Upload uploads a file to GCS and returns the public URL
-func (g *GCSClient) Upload(ctx context.Context, fileName string, file io.Reader) (string, error) {
+func (g *GCSClient) Upload(ctx context.Context, fileName string, file io.Reader, contentType string) (string, error) {
 	bucket := g.client.Bucket(g.bucketName)
 	obj := bucket.Object(fileName)
 
 	writer := obj.NewWriter(ctx)
+	writer.ContentType = contentType
+	writer.CacheControl = "public, max-age=3600"
 	defer writer.Close()
 
 	if _, err := io.Copy(writer, file); err != nil {


### PR DESCRIPTION
## 概要
GCSアップロード時にContent-TypeとCache-Controlヘッダーを設定し、画像のクロスオリジン表示エラーERR_BLOCKED_BY
_ORB）を修正

## 問題
- GCSに画像アップロード時、Content-Typeが未設定のためブラウザのORB（Opaque Response
Blocking）でブロックされていた
- 特にSVG画像がクロスオリジンで表示されない

## 変更内容
- `gcs.go`: アップロード時に`Content-Type`と`Cache-Control`(1時間)を設定
- `image.go`: ファイル拡張子から適切なMIMEタイプを判定する関数を追加