### PR TITLE
bug: upload/fileのレスポンスがカンマ区切りになるよう修正

### DIFF
--- a/app/interfaces/handler/image.go
+++ b/app/interfaces/handler/image.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"path/filepath"
+	"encoding/json"
 
 	"github.com/go-chi/chi"
 	"github.com/google/uuid"
@@ -75,7 +76,8 @@ func (h *ImageHandler) UploadImage(w http.ResponseWriter, r *http.Request) {
 	// Return response in same format as file-server
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, `{"urls":%q}`, urls)
+	urlsJson, _ := json.Marshal(urls)
+	fmt.Fprintf(w, `{"urls":%s}`, string(urlsJson))
 }
 
 // DeleteImage handles image deletion from GCS


### PR DESCRIPTION
## 概要

(Issueなし)
これにより，複数画像の作品投稿を行う際に，JSONのSyntax Errorによりj
upload/file におけるレスポンスが以下のようになっており，JSONのSyntax Errorが発生していた．
具体的には，imageUrlとimageUrlがスペース区切りになっている．これをカンマ区切りに修正．


```json
{"urls":[
  "http://localhost:4443/storage/v1/b/funcy-portfolio-images/o/056daa26-7341-4e44-9b84-70d9da83fc26.png?alt=media"
  "http://localhost:4443/storage/v1/b/funcy-portfolio-images/o/2f2d7062-8c4b-4610-81b5-b52b269c70c6.png?alt=media"
  "http://localhost:4443/storage/v1/b/funcy-portfolio-images/o/54f242f1-563b-4c5d-8864-25d3186e4cbc.jpeg?alt=media"
]}
```

## 変更点

- `encoding/json`パッケージを用いて，url配列のスペース区切りをカンマ区切りに変更した．
- フロント側で動作確認済み．ブラウザ上でレスポンスのスタイルが正しいことも確認済み．

```json
{"urls":[
  "http://localhost:4443/storage/v1/b/funcy-portfolio-images/o/056daa26-7341-4e44-9b84-70d9da83fc26.png?alt=media",
  "http://localhost:4443/storage/v1/b/funcy-portfolio-images/o/2f2d7062-8c4b-4610-81b5-b52b269c70c6.png?alt=media",
  "http://localhost:4443/storage/v1/b/funcy-portfolio-images/o/54f242f1-563b-4c5d-8864-25d3186e4cbc.jpeg?alt=media"
]}
```